### PR TITLE
회원정보 페이지 내 관련 기능 추가

### DIFF
--- a/src/main/java/highfive/nowness/controller/UserApiController.java
+++ b/src/main/java/highfive/nowness/controller/UserApiController.java
@@ -18,6 +18,7 @@ public class UserApiController {
 
     private final UserDetailsService userDetailsService;
     private final PasswordEncoder passwordEncoder;
+
     @Autowired
     UserApiController(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
         this.userDetailsService = userDetailsService;
@@ -41,6 +42,12 @@ public class UserApiController {
         return ResponseEntity.ok().body(isExist);
     }
 
+    /**
+     * 비밀번호 찾기 메뉴를 통해 입력받은 정보로 비밀번호 초기화 메일을 발송합니다.
+     * @param request 사용자 요청에 대한 정보를 갖고 있습니다.
+     * @param findPasswordForm 사용자가 비밀번호를 재설정하기 위해 입력한 메일 정보를 갖고 있습니다.
+     * @return 존재하는 이메일일 경우 200 OK, 그렇지 않을 경우 204 No Content 반환
+     */
     @PostMapping("/password")
     public ResponseEntity<Boolean> findPassword(HttpServletRequest request, @RequestBody FindPasswordForm findPasswordForm) {
         AtomicReference<ResponseEntity<Boolean>> responseEntity = new AtomicReference<>(ResponseEntity.ok(true));
@@ -57,12 +64,11 @@ public class UserApiController {
         try {
             return Optional.of((User) userDetailsService.loadUserByEmail(email));
         } catch (Exception e) {
-            e.printStackTrace();
             return Optional.empty();
         }
     }
 
-    private record FindPasswordForm(String email) {}
+    private record FindPasswordForm(String email) { }
 
     @PutMapping("/password")
     public ResponseEntity<Boolean> resetPassword(@RequestBody ResetPasswordForm resetPasswordForm) {

--- a/src/main/java/highfive/nowness/controller/UserApiController.java
+++ b/src/main/java/highfive/nowness/controller/UserApiController.java
@@ -45,10 +45,10 @@ public class UserApiController {
     public ResponseEntity<Boolean> findPassword(HttpServletRequest request, @RequestBody FindPasswordForm findPasswordForm) {
         AtomicReference<ResponseEntity<Boolean>> responseEntity = new AtomicReference<>(ResponseEntity.ok(true));
         getUserInfo(findPasswordForm.email()).ifPresentOrElse(user -> {
-            String resetCode = UserUtil.getRandomUUID().toString();
-            userDetailsService.sendPasswordResetEmail(user, "http://%s".formatted(request.getHeader("host")), resetCode);
-            userDetailsService.savePasswordResetEmail(resetCode, findPasswordForm.email());
-            },
+                    String resetCode = UserUtil.getRandomCode();
+                    userDetailsService.sendPasswordResetEmail(user, "http://%s".formatted(request.getHeader("host")), resetCode);
+                    userDetailsService.savePasswordResetEmail(resetCode, findPasswordForm.email());
+                },
                 () -> responseEntity.set(ResponseEntity.noContent().build()));
         return responseEntity.get();
     }

--- a/src/main/java/highfive/nowness/controller/UserController.java
+++ b/src/main/java/highfive/nowness/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
     }
 
     @PostMapping("/signup")
-    public String processSignup(SignUpForm signUpForm, HttpServletRequest request) {
+    public String processIdPwSignup(SignUpForm signUpForm, HttpServletRequest request) {
         if (isDuplicateUserInfo(signUpForm)) return "redirect:/user/signup";
         User user = signUpForm.toUser(passwordEncoder, request);
         userDetailsService.saveUser(user);

--- a/src/main/java/highfive/nowness/controller/UserController.java
+++ b/src/main/java/highfive/nowness/controller/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
         if (isDuplicateUserInfo(signUpForm)) return "redirect:/user/signup";
         User user = signUpForm.toUser(passwordEncoder, request);
         userDetailsService.saveUser(user);
-        String code = UserUtil.getRandomUUID().toString();
+        String code = UserUtil.getRandomCode();
         userDetailsService.sendVerificationEmail(user, "http://%s".formatted(request.getHeader("host")), code);
         userDetailsService.saveUnverifiedEmail(code, user.getEmail());
         return "welcome_signup";
@@ -77,7 +77,7 @@ public class UserController {
     // 테스트용
     @GetMapping("/testmail")
     public String testMail() {
-        String code = UserUtil.getRandomUUID().toString();
+        String code = UserUtil.getRandomCode();
         String email = "--@gmail.com";
         userDetailsService.sendVerificationEmail(User.builder()
                         .email(email)

--- a/src/main/java/highfive/nowness/controller/UserController.java
+++ b/src/main/java/highfive/nowness/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
         User user = signUpForm.toUser(passwordEncoder, request);
         userDetailsService.saveUser(user);
         String code = UserUtil.getRandomCode();
-        userDetailsService.sendVerificationEmail(user, "http://%s".formatted(request.getHeader("host")), code);
+        userDetailsService.sendVerificationEmail(user, UserUtil.getHost(), code);
         userDetailsService.saveUnverifiedEmail(code, user.getEmail());
         return "welcome_signup";
     }

--- a/src/main/java/highfive/nowness/controller/UserController.java
+++ b/src/main/java/highfive/nowness/controller/UserController.java
@@ -106,7 +106,17 @@ public class UserController {
                              Model model) {
         if (user == null) user = UserUtil.convertOAuth2UserToUser(oAuth2User);
         UserUtil.addPublicUserInfoToModel(model, user);
+        addRecentContentsAndRepliesToModel(model, user);
         return "mypage";
+    }
+
+    private void addRecentContentsAndRepliesToModel(Model model, User user) {
+        var contents = userDetailsService.getRecentContentsAndReplies(user.getId()).stream().filter(row ->
+                row.get("type").equals("contents")).toList();
+        var replies = userDetailsService.getRecentContentsAndReplies(user.getId()).stream().filter(row ->
+                row.get("type").equals("replies")).toList();
+        model.addAttribute("contents", contents);
+        model.addAttribute("replies", replies);
     }
 
 }

--- a/src/main/java/highfive/nowness/controller/UserController.java
+++ b/src/main/java/highfive/nowness/controller/UserController.java
@@ -105,9 +105,7 @@ public class UserController {
                              @AuthenticationPrincipal OAuth2User oAuth2User,
                              Model model) {
         if (user == null) user = UserUtil.convertOAuth2UserToUser(oAuth2User);
-        model.addAttribute("id", user.getId());
-        model.addAttribute("email", user.getEmail());
-        model.addAttribute("nickname", user.getNickname());
+        UserUtil.addPublicUserInfoToModel(model, user);
         return "mypage";
     }
 

--- a/src/main/java/highfive/nowness/repository/BoardRepository.java
+++ b/src/main/java/highfive/nowness/repository/BoardRepository.java
@@ -1,0 +1,13 @@
+package highfive.nowness.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+
+@Mapper
+@Repository
+public interface BoardRepository {
+    List<Map<String, String>> loadRecentContentsAndReplies(long userId);
+}

--- a/src/main/java/highfive/nowness/repository/UserRepository.java
+++ b/src/main/java/highfive/nowness/repository/UserRepository.java
@@ -21,4 +21,5 @@ public interface UserRepository {
     int countPasswordResetEmail(String code);
     void resetPassword(Map<String, Object> params);
     int changePasswordByEmail(String email, String newPassword);
+    int changeNicknameByEmail(String email, String newNickname);
 }

--- a/src/main/java/highfive/nowness/repository/UserRepository.java
+++ b/src/main/java/highfive/nowness/repository/UserRepository.java
@@ -20,4 +20,5 @@ public interface UserRepository {
     void savePasswordResetEmail(String code, String email);
     int countPasswordResetEmail(String code);
     void resetPassword(Map<String, Object> params);
+    int changePasswordByEmail(String email, String newPassword);
 }

--- a/src/main/java/highfive/nowness/service/UserDetailsService.java
+++ b/src/main/java/highfive/nowness/service/UserDetailsService.java
@@ -2,6 +2,7 @@ package highfive.nowness.service;
 
 import highfive.nowness.domain.User;
 import highfive.nowness.dto.UserDTO;
+import highfive.nowness.repository.BoardRepository;
 import highfive.nowness.repository.UserRepository;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,17 +14,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
 public class UserDetailsService implements UserService {
 
     private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
     private final JavaMailSender javaMailSender;
 
     @Autowired
-    UserDetailsService(UserRepository userRepository, JavaMailSender javaMailSender) {
+    UserDetailsService(UserRepository userRepository, JavaMailSender javaMailSender, BoardRepository boardRepository) {
         this.userRepository = userRepository;
+        this.boardRepository = boardRepository;
         this.javaMailSender = javaMailSender;
     }
 
@@ -192,5 +196,10 @@ public class UserDetailsService implements UserService {
     @Transactional
     public boolean changeNickname(String email, String newNickname) {
         return userRepository.changeNicknameByEmail(email, newNickname) == 1;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Map<String, String>> getRecentContentsAndReplies(long userId) {
+        return boardRepository.loadRecentContentsAndReplies(userId);
     }
 }

--- a/src/main/java/highfive/nowness/service/UserDetailsService.java
+++ b/src/main/java/highfive/nowness/service/UserDetailsService.java
@@ -64,11 +64,6 @@ public class UserDetailsService implements UserService {
         return new User(userDto);
     }
 
-    /**
-     * 저장소에 신규 사용자 정보를 저장합니다.
-     * @param user 사용자 도메인 클래스
-     * @author 정성국
-     */
     @Transactional
     public void saveUser(User user) {
         userRepository.save(UserDTO.builder()
@@ -142,10 +137,10 @@ public class UserDetailsService implements UserService {
 
     private MimeMessage convertEmailToMimeMessage(Email email, MimeMessageHelper helper) {
         try {
-            helper.setFrom(email.fromAddress, email.senderName);
-            helper.setTo(email.toAddress);
-            helper.setSubject(email.subject);
-            helper.setText(email.content, true);
+            helper.setFrom(email.fromAddress(), email.senderName());
+            helper.setTo(email.toAddress());
+            helper.setSubject(email.subject());
+            helper.setText(email.content(), true);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/highfive/nowness/service/UserDetailsService.java
+++ b/src/main/java/highfive/nowness/service/UserDetailsService.java
@@ -188,4 +188,9 @@ public class UserDetailsService implements UserService {
     public boolean changePassword(String email, String newPassword) {
         return userRepository.changePasswordByEmail(email, newPassword) == 1;
     }
+
+    @Transactional
+    public boolean changeNickname(String email, String newNickname) {
+        return userRepository.changeNicknameByEmail(email, newNickname) == 1;
+    }
 }

--- a/src/main/java/highfive/nowness/service/UserDetailsService.java
+++ b/src/main/java/highfive/nowness/service/UserDetailsService.java
@@ -176,12 +176,16 @@ public class UserDetailsService implements UserService {
     }
 
     @Transactional
-    public boolean resetPasswordByResetCode(String code, String password) {
+    public boolean resetPasswordByResetCode(String code, String newPassword) {
         Map<String, Object> params = new HashMap<>();
         params.put("code", code);
-        params.put("newPassword", password);
+        params.put("newPassword", newPassword);
         userRepository.resetPassword(params);
         return (int) params.get("updatedRows") == 1;
     }
 
+    @Transactional
+    public boolean changePassword(String email, String newPassword) {
+        return userRepository.changePasswordByEmail(email, newPassword) == 1;
+    }
 }

--- a/src/main/java/highfive/nowness/util/UserUtil.java
+++ b/src/main/java/highfive/nowness/util/UserUtil.java
@@ -31,4 +31,8 @@ public class UserUtil {
         return UUID.randomUUID().toString();
     }
 
+    public static String getHost() {
+        return "http://localhost:8080";
+    }
+
 }

--- a/src/main/java/highfive/nowness/util/UserUtil.java
+++ b/src/main/java/highfive/nowness/util/UserUtil.java
@@ -18,8 +18,8 @@ public class UserUtil {
         return user == null && oAuth2User == null;
     }
 
-    public static UUID getRandomUUID() {
-        return UUID.randomUUID();
+    public static String getRandomCode() {
+        return UUID.randomUUID().toString();
     }
 
 }

--- a/src/main/java/highfive/nowness/util/UserUtil.java
+++ b/src/main/java/highfive/nowness/util/UserUtil.java
@@ -2,6 +2,7 @@ package highfive.nowness.util;
 
 import highfive.nowness.domain.User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.ui.Model;
 
 import java.util.UUID;
 
@@ -11,7 +12,15 @@ public class UserUtil {
                 .id(oAuth2User.getAttribute("id"))
                 .email(oAuth2User.getAttribute("email"))
                 .nickname(oAuth2User.getAttribute("nickname"))
+                .verifiedEmail(true)
                 .build();
+    }
+
+    public static void addPublicUserInfoToModel(Model model, User user) {
+        model.addAttribute("id", user.getId());
+        model.addAttribute("email", user.getEmail());
+        model.addAttribute("nickname", user.getNickname());
+        model.addAttribute("verifiedUser", user.isVerifiedEmail());
     }
 
     public static boolean isNotLogin(User user, OAuth2User oAuth2User) {

--- a/src/main/resources/mapper/board-mapper.xml
+++ b/src/main/resources/mapper/board-mapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="highfive.nowness.repository.BoardRepository">
+    <select id="loadRecentContentsAndReplies" parameterType="long" resultType="java.util.HashMap">
+        (SELECT 'contents' AS type,
+                c.id AS contentsId,
+                c.contents AS contents,
+                c.created_datetime AS datetime
+         FROM Contents c
+         WHERE c.user_id = 1 ORDER BY c.created_datetime DESC LIMIT 0, 5)
+        UNION ALL
+        (SELECT 'replies' AS type,
+                r.contents_id AS contentsId,
+                r.reply AS contents,
+                r.created_datetime AS datetime
+         FROM Replies r
+         WHERE r.user_id = 1 ORDER BY r.created_datetime DESC LIMIT 0, 5);
+    </select>
+</mapper>

--- a/src/main/resources/mapper/user-mapper.xml
+++ b/src/main/resources/mapper/user-mapper.xml
@@ -57,4 +57,8 @@
     <select id="resetPassword" statementType="CALLABLE" parameterType="map">
         {CALL reset_password(#{code, mode=IN, jdbcType=VARCHAR}, #{newPassword, mode=IN, jdbcType=VARCHAR}, #{updatedRows, mode=OUT, jdbcType=INTEGER})}
     </select>
+
+    <update id="changePasswordByEmail" parameterType="String">
+        UPDATE users SET password = #{arg1}, last_password_changed = now() WHERE email = #{arg0}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/user-mapper.xml
+++ b/src/main/resources/mapper/user-mapper.xml
@@ -61,4 +61,8 @@
     <update id="changePasswordByEmail" parameterType="String">
         UPDATE users SET password = #{arg1}, last_password_changed = now() WHERE email = #{arg0}
     </update>
+
+    <update id="changeNicknameByEmail" parameterType="String">
+        UPDATE users SET nickname = #{arg1} WHERE email = #{arg0}
+    </update>
 </mapper>

--- a/src/main/resources/static/js/user/find_password.js
+++ b/src/main/resources/static/js/user/find_password.js
@@ -5,7 +5,7 @@ $(document).ready(() => {
         if (!email.hasClass('is-invalid')) requestToServer('duplicate', email);
     });
 
-    email.on("keydown", function(event) {
+    email.keydown((event)=> {
         if (event.key === "Enter" && $(this).is(':focus') && $(this).hasClass('is-valid')) {
             requestPasswordResetEmail(email);
         }

--- a/src/main/resources/static/js/user/login_signup.js
+++ b/src/main/resources/static/js/user/login_signup.js
@@ -1,4 +1,5 @@
 $(document).ready(() => {
+
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
     const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
 
@@ -141,7 +142,6 @@ function duplicationCheck(type, value) {
     const data = {
         [type]: value,
     }
-    console.log(data);
     request('/api/v1/user/duplicate', 'POST', data, $('input[name="_csrf"]').val())
 }
 
@@ -158,7 +158,7 @@ function request(url, method, data, csrfToken) {
         success: function(response) {
             if(response === true) {
                 disableSubmitButton();
-                if (data.hasOwnProperty("email")) {
+                if (data.hasOwnProperty('email')) {
                     $('#floatingEmail').addClass('is-invalid');
                     $('#emailValidationFeedback').text('중복된 이메일 입니다.');
                 } else {
@@ -168,7 +168,7 @@ function request(url, method, data, csrfToken) {
             }
         },
         error: function(xhr, status, error) {
-            alert("중복 검사 중 오류가 발생하였습니다. 나중에 다시 시도해주세요.");
+            alert('중복 검사 중 오류가 발생하였습니다. 나중에 다시 시도해주세요.');
         }
     });
 }

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -4,10 +4,17 @@ $(document).ready(function() {
     const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
 
     const modal = $('#modal');
+    const passwordInput = $('#passwordInput');
+    const nicknameInput = $('#nicknameInput');
 
     modal.on('show.bs.modal', function(event) {
 
         const button = $(event.relatedTarget);
+        disableRequestButton();
+        passwordInput.removeClass('is-invalid');
+        passwordInput.removeClass('is-valid');
+        nicknameInput.removeClass('is-invalid');
+        nicknameInput.removeClass('is-valid');
         const value = button.attr('data-bs-whatever');
         const modalTitle = modal.find('.modal-title');
 
@@ -19,13 +26,14 @@ $(document).ready(function() {
         if (isPasswordChange) {
             nicknameForm.hide();
             passwordForm.show();
+            passwordInput.val('');
         } else {
             nicknameForm.show();
             passwordForm.hide();
+            nicknameInput.val(value);
         }
 
         modalTitle.text(isPasswordChange ? '비밀번호 변경하기' : '닉네임 변경하기');
-        $('#nickname').val(value);
     });
 
     const verifyMailSendBtn = $('#btnVerifyMailSend');
@@ -37,17 +45,36 @@ $(document).ready(function() {
         resendVerifyMail();
     });
 
+    const changeNicknameBtn = $('#btnChangeNickname');
+
+    changeNicknameBtn.click(() => {
+        passwordInput.val('');
+    });
+
+    const changePasswordBtn = $('#btnChangePassword');
+
+    changePasswordBtn.click(() => {
+        nicknameInput.val('');
+    });
+
     const changeRequestBtn = $('#btnChangeRequest');
-    const passwordInput = $('#password');
 
     changeRequestBtn.click(() => {
 
         changeRequestBtn.hide();
         $('#btnChangingInfoMessage').show();
         const newPassword = passwordInput.val();
+        const newNickname = nicknameInput.val();
         if (newPassword.length >= 8) {
+            console.log(newPassword.length);
             changePassword(newPassword);
+        } else if (newNickname.length >= 3 && newNickname.length <= 8) {
+            changeNickname(newNickname);
         }
+    });
+
+    nicknameInput.keyup(() => {
+        if (validateNickname(nicknameInput)) checkDuplicateNickname(nicknameInput.val());
     });
 
     passwordInput.keyup(() => {
@@ -56,12 +83,37 @@ $(document).ready(function() {
 
 });
 
-// password 입력에 대한 html element 를 받아서 검증합니다.
+// 닉네임 입력에 대한 html element 를 받아서 검증합니다.
+function validateNickname(nicknameInput) {
+
+    if (nicknameInput.val() === $('#nickname').text()) {
+        nicknameInput.addClass('is-invalid');
+        nicknameInput.removeClass('is-valid');
+        disableRequestButton();
+        $('#nicknameValidationFeedback').text('기존 닉네임과 동일합니다.');
+        return false;
+    }
+
+    const regex = /^[가-힣a-zA-Z0-9]{3,8}$/;
+    if (regex.test(nicknameInput.val())) {
+        nicknameInput.addClass('is-valid');
+        nicknameInput.removeClass('is-invalid');
+        return true;
+    } else {
+        nicknameInput.addClass('is-invalid');
+        nicknameInput.removeClass('is-valid');
+        disableRequestButton();
+        $('#nicknameValidationFeedback').text('한글, 영어(대/소문자), 숫자로만 입력할 수 있으며 3~8글자만 입력 가능합니다.');
+        return false;
+    }
+}
+
+// 비밀번호 입력에 대한 html element 를 받아서 검증합니다.
 function validatePassword(password) {
     const regex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/;
     if (regex.test(password.val())) {
-        password.removeClass('is-invalid');
         password.addClass('is-valid');
+        password.removeClass('is-invalid');
         enableRequestButton();
     } else {
         password.addClass('is-invalid');
@@ -80,6 +132,7 @@ function disableRequestButton() {
 
 const path = '/api/v1/user/';
 const emailResourceName = 'unverified-email';
+const nicknameResourceName = 'nickname';
 const passwordResourceName = 'password';
 
 function resendVerifyMail() {
@@ -88,7 +141,27 @@ function resendVerifyMail() {
         email: $('#email').text(),
     };
 
-    requestAjax(path, emailResourceName, method, data);
+    requestAjax(emailResourceName, method, JSON.stringify(data));
+}
+
+// 닉네임 입력 값을 받아서 중복 여부를 검사합니다.
+function checkDuplicateNickname(newNickname) {
+    const method = 'GET';
+    const data = {
+        newNickname: newNickname,
+    };
+
+    requestAjax(nicknameResourceName, method, data);
+}
+
+function changeNickname(newNickname) {
+    const method = 'PATCH';
+    const data = {
+        email: $('#email').text(),
+        newNickname: newNickname,
+    };
+
+    requestAjax(nicknameResourceName, method, JSON.stringify(data));
 }
 
 function changePassword(newPassword) {
@@ -98,15 +171,15 @@ function changePassword(newPassword) {
         newPassword: newPassword,
     };
 
-    requestAjax(path, passwordResourceName, method, data);
+    requestAjax(passwordResourceName, method, JSON.stringify(data));
 }
 
-function requestAjax(path, resource, method, data) {
+function requestAjax(resource, method, data) {
     $.ajax({
         url: path + resource,
         type: method,
         dataType: 'json',
-        data: JSON.stringify(data),
+        data: data,
         contentType: 'application/json',
         headers: {
             'X-CSRF-TOKEN': $('input[name="_csrf"]').val(),
@@ -115,17 +188,36 @@ function requestAjax(path, resource, method, data) {
             if (resource === emailResourceName && status === 'success') {
                 $('#btnEmailSendingMessage').hide();
                 alert('인증 메일이 재발송되었습니다.');
+            } else if (resource === nicknameResourceName && status === 'success') {
+                const nicknameInput = $('#nicknameInput');
+                if (response['responseJSON'] === true) {
+                    nicknameInput.addClass('is-invalid');
+                    nicknameInput.removeClass('is-valid');
+                    disableRequestButton();
+                    $('#nicknameValidationFeedback').text('중복된 닉네임 입니다.');
+                } else {
+                    nicknameInput.addClass('is-valid');
+                    nicknameInput.removeClass('is-invalid');
+                    enableRequestButton();
+                }
+            } else if (resource === nicknameResourceName && status === 'nocontent') {
+                $('#nickname').text(JSON.parse(this.data).newNickname);
+                $('#btnChangingInfoMessage').hide();
+                $('#btnChangeRequest').show();
+                alert('닉네임이 변경되었습니다.');
+                disableRequestButton()
             } else if (resource === passwordResourceName && status === 'nocontent') {
                 $('#btnChangingInfoMessage').hide();
                 $('#btnChangeRequest').show();
                 alert('비밀번호가 변경되었습니다.');
+                disableRequestButton()
             }
         },
         error: function (xhr, status, error) {
             alert('오류가 발생하였습니다. 나중에 다시 시도해주세요.');
-            if (resource === emailResourceName && status === 'success') {
+            if (resource === emailResourceName) {
                 $('#btnVerifyMailSend').show();
-            } else if (resource === passwordResourceName && status === 'nocontent') {
+            } else {
                 $('#btnChangingInfoMessage').hide();
                 $('#btnChangeRequest').show();
             }

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -1,5 +1,8 @@
 $(document).ready(function() {
 
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+
     const nicknameModal = $('#modal');
 
     nicknameModal.on('show.bs.modal', function(event) {

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -29,4 +29,48 @@ $(document).ready(function() {
         modalBodyInput.val(isPasswordChange ? '' : value);
     });
 
+    const verifyMailSendBtn = $('#btnVerifyMailSend');
+
+    // 인증 메일을 재발송한 후 여러번 클릭하는 것을 막기 위해 숨깁니다.
+    verifyMailSendBtn.click(() => {
+        verifyMailSendBtn.hide();
+        $('#btnEmailSending').show();
+        resendVerifyMail();
+    });
+
 });
+
+const path = '/api/v1/user/';
+
+function resendVerifyMail() {
+    const resource = 'unverified-email';
+    const method = 'POST';
+    const data = {
+        email: $('#email').text(),
+    };
+
+    requestAjax(path, resource, method, data);
+}
+
+function requestAjax(path, resource, method, data) {
+    $.ajax({
+        url: path + resource,
+        type: method,
+        dataType: 'json',
+        data: JSON.stringify(data),
+        contentType: 'application/json',
+        headers: {
+            'X-CSRF-TOKEN': $('input[name="_csrf"]').val(),
+        },
+        success: function (xhr, status, response) {
+            if (resource === 'unverified-email' && status === 'success') {
+                $('#btnEmailSending').hide();
+                alert('인증 메일이 재발송되었습니다.');
+            }
+        },
+        error: function (xhr, status, error) {
+            alert('오류가 발생하였습니다. 나중에 다시 시도해주세요.');
+            $('#btnVerifyMailSend').show();
+        }
+    });
+}

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -3,19 +3,18 @@ $(document).ready(function() {
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
     const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
 
-    const nicknameModal = $('#modal');
+    const modal = $('#modal');
 
-    nicknameModal.on('show.bs.modal', function(event) {
+    modal.on('show.bs.modal', function(event) {
 
         const button = $(event.relatedTarget);
         const value = button.attr('data-bs-whatever');
-        const modalTitle = nicknameModal.find('.modal-title');
-        const modalBodyInput = nicknameModal.find('.modal-body input');
+        const modalTitle = modal.find('.modal-title');
+
+        const nicknameForm = $('#nicknameForm');
+        const passwordForm = $('#passwordForm');
 
         const isPasswordChange = value === 'password-change';
-
-        const nicknameForm = nicknameModal.find('#nicknameForm');
-        const passwordForm = nicknameModal.find('#passwordForm');
 
         if (isPasswordChange) {
             nicknameForm.hide();
@@ -26,30 +25,80 @@ $(document).ready(function() {
         }
 
         modalTitle.text(isPasswordChange ? '비밀번호 변경하기' : '닉네임 변경하기');
-        modalBodyInput.val(isPasswordChange ? '' : value);
+        $('#nickname').val(value);
     });
 
     const verifyMailSendBtn = $('#btnVerifyMailSend');
 
-    // 인증 메일을 재발송한 후 여러번 클릭하는 것을 막기 위해 숨깁니다.
+    // 인증 메일을 재발송한 후 여러번 클릭하는 것을 막기 위해 버튼을 숨깁니다.
     verifyMailSendBtn.click(() => {
         verifyMailSendBtn.hide();
-        $('#btnEmailSending').show();
+        $('#btnEmailSendingMessage').show();
         resendVerifyMail();
+    });
+
+    const changeRequestBtn = $('#btnChangeRequest');
+    const passwordInput = $('#password');
+
+    changeRequestBtn.click(() => {
+
+        changeRequestBtn.hide();
+        $('#btnChangingInfoMessage').show();
+        const newPassword = passwordInput.val();
+        if (newPassword.length >= 8) {
+            changePassword(newPassword);
+        }
+    });
+
+    passwordInput.keyup(() => {
+        validatePassword(passwordInput);
     });
 
 });
 
+// password 입력에 대한 html element 를 받아서 검증합니다.
+function validatePassword(password) {
+    const regex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/;
+    if (regex.test(password.val())) {
+        password.removeClass('is-invalid');
+        password.addClass('is-valid');
+        enableRequestButton();
+    } else {
+        password.addClass('is-invalid');
+        password.removeClass('is-valid');
+        disableRequestButton();
+    }
+}
+
+function enableRequestButton() {
+    $('#btnChangeRequest').prop('disabled', false);
+}
+
+function disableRequestButton() {
+    $('#btnChangeRequest').prop('disabled', true);
+}
+
 const path = '/api/v1/user/';
+const emailResourceName = 'unverified-email';
+const passwordResourceName = 'password';
 
 function resendVerifyMail() {
-    const resource = 'unverified-email';
     const method = 'POST';
     const data = {
         email: $('#email').text(),
     };
 
-    requestAjax(path, resource, method, data);
+    requestAjax(path, emailResourceName, method, data);
+}
+
+function changePassword(newPassword) {
+    const method = 'PATCH';
+    const data = {
+        email: $('#email').text(),
+        newPassword: newPassword,
+    };
+
+    requestAjax(path, passwordResourceName, method, data);
 }
 
 function requestAjax(path, resource, method, data) {
@@ -63,14 +112,23 @@ function requestAjax(path, resource, method, data) {
             'X-CSRF-TOKEN': $('input[name="_csrf"]').val(),
         },
         success: function (xhr, status, response) {
-            if (resource === 'unverified-email' && status === 'success') {
-                $('#btnEmailSending').hide();
+            if (resource === emailResourceName && status === 'success') {
+                $('#btnEmailSendingMessage').hide();
                 alert('인증 메일이 재발송되었습니다.');
+            } else if (resource === passwordResourceName && status === 'nocontent') {
+                $('#btnChangingInfoMessage').hide();
+                $('#btnChangeRequest').show();
+                alert('비밀번호가 변경되었습니다.');
             }
         },
         error: function (xhr, status, error) {
             alert('오류가 발생하였습니다. 나중에 다시 시도해주세요.');
-            $('#btnVerifyMailSend').show();
+            if (resource === emailResourceName && status === 'success') {
+                $('#btnVerifyMailSend').show();
+            } else if (resource === passwordResourceName && status === 'nocontent') {
+                $('#btnChangingInfoMessage').hide();
+                $('#btnChangeRequest').show();
+            }
         }
     });
 }

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -1,15 +1,29 @@
 $(document).ready(function() {
 
-    const nicknameModal = document.getElementById('nicknameModal');
-    nicknameModal.addEventListener('show.bs.modal', event => {
+    const nicknameModal = $('#modal');
 
-        const button = event.relatedTarget;// 닉네임 변경 버튼
-        const nickname = button.getAttribute('data-bs-whatever');
-        const modalTitle = nicknameModal.querySelector('.modal-title');
-        const modalBodyInput = nicknameModal.querySelector('.modal-body input');
+    nicknameModal.on('show.bs.modal', function(event) {
 
-        modalTitle.textContent = `닉네임 변경하기`;
-        modalBodyInput.value = nickname;
+        const button = $(event.relatedTarget);
+        const value = button.attr('data-bs-whatever');
+        const modalTitle = nicknameModal.find('.modal-title');
+        const modalBodyInput = nicknameModal.find('.modal-body input');
+
+        const isPasswordChange = value === 'password-change';
+
+        const nicknameForm = nicknameModal.find('#nicknameForm');
+        const passwordForm = nicknameModal.find('#passwordForm');
+
+        if (isPasswordChange) {
+            nicknameForm.hide();
+            passwordForm.show();
+        } else {
+            nicknameForm.show();
+            passwordForm.hide();
+        }
+
+        modalTitle.text(isPasswordChange ? '비밀번호 변경하기' : '닉네임 변경하기');
+        modalBodyInput.val(isPasswordChange ? '' : value);
     });
 
 });

--- a/src/main/resources/templates/email_verified.html
+++ b/src/main/resources/templates/email_verified.html
@@ -16,6 +16,6 @@
     </div>
   </div>
 </div>
-<!--<div th:insert="~{footer :: footer}"></div>-->
+<div th:insert="~{footer :: footer}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/find_password.html
+++ b/src/main/resources/templates/find_password.html
@@ -40,6 +40,6 @@
     </div>
   </div>
 </div>
-<!--<div th:insert="~{footer :: footer}"></div>-->
+<div th:insert="~{footer :: footer}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -14,17 +14,17 @@
                     <div class="col-12 d-flex justify-content-end">
                         <ul class="navbar-nav">
                             <li class="nav-item">
-                                <a class="nav-link text-dark user-link" href="login">로그인</a>
+                                <a class="nav-link text-dark user-link" href="/user/login">로그인</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-dark user-link" href="signup">회원가입</a>
+                                <a class="nav-link text-dark user-link" href="/user/signup">회원가입</a>
                             </li>
                         </ul>
                     </div>
 
                     <div class="col-12 d-flex justify-content-center my-5">
-                        <a class="navbar-brand d-flex align-items-center justify-content-center logo-position" href="main">
-                            <img src="images/logo.png" alt="Logo" width="150" height="120">
+                        <a class="navbar-brand d-flex align-items-center justify-content-center logo-position" href="/main">
+                            <img th:src="@{/images/logo.png}" alt="Logo" width="150" height="120">
                         </a>
                     </div>
 

--- a/src/main/resources/templates/login_signup.html
+++ b/src/main/resources/templates/login_signup.html
@@ -39,7 +39,7 @@
                                aria-describedby="passwordValidationFeedback" required>
                         <label for="floatingPassword">비밀번호</label>
                         <div id="passwordValidationFeedback" class="invalid-feedback">
-                            비밀번호를 확인해주세요.
+                            비밀번호는 영문자, 숫자, 특수문자 조합으로 8글자 이상 작성하여야 합니다.
                         </div>
                     </div>
                     <div th:if="${#ctx.springRequestContext.requestUri} == '/user/signup'" class="form-floating mt-3 mb-3">

--- a/src/main/resources/templates/login_signup.html
+++ b/src/main/resources/templates/login_signup.html
@@ -115,6 +115,6 @@
         </div>
     </div>
 </div>
-<!--<div th:insert="~{footer :: footer}"></div>-->
+<div th:insert="~{footer :: footer}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -24,7 +24,7 @@
 
                 <div class="row mt-3 justify-content-center">
                     <h4 class="text-center" th:text="${nickname}">nickname</h4>
-                    <p class="text-center" th:text="${email}">example@example.com</p>
+                    <p id="email" class="text-center" th:text="${email}">example@example.com</p>
                 </div>
 
                 <div class="row m-4 mb-0 mt-0"><hr></div>
@@ -32,14 +32,20 @@
                 <div class="row justify-content-start">
                     <h5 class="text-center pb-2">계정 관리 메뉴</h5>
                     <th:block th:unless="${verifiedUser}">
-                    <button class="btn-secondary btn-warning text-dark container-fluid p-3 pt-1 pb-1 pt-0"
+                    <button id="btnVerifyMailSend" class="btn-secondary btn-warning text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
                             data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="아직 인증되지 않았어요!">인증 이메일 재발송</button>
+                    <button id="btnEmailSending" class="btn-secondary btn-warning text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
+                            style="display: none"
+                            type="button" disabled>
+                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                        이메일 발송 중...
+                    </button>
                     </th:block>
-                    <button class="btn-outline-secondary text-dark container-fluid mt-2 p-3 pt-1 pb-1 pt-0"
+                    <button class="btn-outline-secondary text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
                        data-bs-toggle="modal" data-bs-target="#modal" th:attr="data-bs-whatever=${nickname}">닉네임 변경</button>
-                    <button class="btn-outline-secondary text-dark container-fluid mt-2 p-3 pt-1 pb-1 pt-0"
+                    <button class="btn-outline-secondary text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
                             data-bs-toggle="modal" data-bs-target="#modal" data-bs-whatever="password-change">비밀번호 변경</button>
-                    <button class="btn-outline-secondary text-dark container-fluid mt-2 p-3 pt-1 pb-1 pt-0">회원 탈퇴</button>
+                    <button class="btn-outline-secondary text-dark container-fluid p-3 pt-1 pb-1 pt-0">회원 탈퇴</button>
 
                     <div class="modal fade" id="modal" tabindex="-1" aria-labelledby="modalLabel" aria-hidden="true">
                         <div class="modal-dialog modal-dialog-centered">

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -16,7 +16,7 @@
     <title>NOWNESS</title>
 </head>
 <body>
-<h1>MYPAGE</h1>
+<div th:insert="~{header :: header}"></div>
 <div class="container mt-5">
     <div class="row justify-content-between">
         <aside class="col-lg-3">
@@ -28,20 +28,31 @@
                 <div class="row m-4 mb-0 mt-0"><hr></div>
                 <div class="row justify-content-start">
                     <h5 class="text-center pb-2">계정 관리 메뉴</h5>
-                    <button href="#" class="btn-outline-secondary container-fluid p-3 pt-1 pb-1 pt-0"
-                       data-bs-toggle="modal" data-bs-target="#nicknameModal" th:attr="data-bs-whatever=${nickname}">닉네임 변경</button>
-                    <div class="modal fade" id="nicknameModal" tabindex="-1" aria-labelledby="nicknameModalLabel" aria-hidden="true">
+
+                    <button class="btn-outline-secondary text-dark container-fluid p-3 pt-1 pb-1 pt-0"
+                       data-bs-toggle="modal" data-bs-target="#modal" th:attr="data-bs-whatever=${nickname}">닉네임 변경</button>
+                    <button class="btn-outline-secondary text-dark container-fluid mt-2 p-3 pt-1 pb-1 pt-0"
+                            data-bs-toggle="modal" data-bs-target="#modal" data-bs-whatever="password-change">비밀번호 변경</button>
+                    <button class="btn-outline-secondary text-dark container-fluid mt-2 p-3 pt-1 pb-1 pt-0">회원 탈퇴</button>
+
+                    <div class="modal fade" id="modal" tabindex="-1" aria-labelledby="modalLabel" aria-hidden="true">
                         <div class="modal-dialog modal-dialog-centered">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h1 class="modal-title fs-5" id="nicknameModalLabel">닉네임 변경</h1>
+                                    <h1 class="modal-title fs-5" id="modalLabel"></h1>
                                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                 </div>
                                 <div class="modal-body">
                                     <form>
                                         <div class="mb-3">
-                                            <label for="nickname" class="col-form-label">변경할 닉네임</label>
-                                            <input type="text" class="form-control" id="nickname" name="nickname">
+                                            <div id="nicknameForm" type="hidden">
+                                                <label for="nickname" class="col-form-label">변경할 닉네임</label>
+                                                <input type="text" class="form-control" id="nickname">
+                                            </div>
+                                            <div id="passwordForm">
+                                                <label for="password" class="col-form-label">변경할 비밀번호</label>
+                                                <input type="password" class="form-control" id="password">
+                                            </div>
                                         </div>
                                     </form>
                                 </div>
@@ -52,7 +63,6 @@
                             </div>
                         </div>
                     </div>
-                    <button class="btn-outline-secondary container-fluid mt-2 p-3 pt-1 pb-1 pt-0">회원 탈퇴</button>
                 </div>
             </div>
         </aside>
@@ -80,6 +90,7 @@
         </section>
     </div>
 </div>
+<div th:insert="~{footer :: footer}"></div>
 
 <!-- thymeleaf prefix 를 사용한 form 이므로 자동으로 hidden type 의 input 태그에 csrf 토큰 값이 자동으로 생성됨-->
 <form method="POST" th:action="@{/user/logout}">

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -34,7 +34,7 @@
                     <th:block th:unless="${verifiedUser}">
                     <button id="btnVerifyMailSend" class="btn-secondary btn-warning text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
                             data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="아직 인증되지 않았어요!">인증 이메일 재발송</button>
-                    <button id="btnEmailSending" class="btn-secondary btn-warning text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
+                    <button id="btnEmailSendingMessage" class="btn-secondary btn-warning text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
                             style="display: none"
                             type="button" disabled>
                         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
@@ -59,18 +59,33 @@
                                         <div class="mb-3">
                                             <div id="nicknameForm" type="hidden">
                                                 <label for="nickname" class="col-form-label">변경할 닉네임</label>
-                                                <input type="text" class="form-control" id="nickname">
+                                                <input type="text" class="form-control" id="nickname"
+                                                       aria-describedby="nicknameValidationFeedback">
+                                                <div id="nicknameValidationFeedback" class="invalid-feedback"
+                                                     style="text-overflow: initial; overflow: visible; white-space: initial;">
+                                                    한글, 영어(대/소문자), 숫자로만 입력할 수 있으며 3~8글자만 입력 가능합니다.
+                                                </div>
                                             </div>
                                             <div id="passwordForm">
                                                 <label for="password" class="col-form-label">변경할 비밀번호</label>
-                                                <input type="password" class="form-control" id="password">
+                                                <input type="password" class="form-control" id="password"
+                                                       aria-describedby="passwordValidationFeedback">
+                                                <div id="passwordValidationFeedback" class="invalid-feedback"
+                                                style="text-overflow: initial; overflow: visible; white-space: initial;">
+                                                    영문자, 숫자, 특수문자 조합으로 8글자 이상 작성하여야 합니다.
+                                                </div>
                                             </div>
                                         </div>
                                     </form>
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
-                                    <button type="button" class="btn btn-primary">변경요청</button>
+                                    <button id="btnChangeRequest" type="button" class="btn btn-primary" disabled>변경요청</button>
+                                    <button id="btnChangingInfoMessage" class="btn btn-primary"
+                                            style="display: none" type="button" disabled>
+                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                        변경 중...
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -81,7 +96,7 @@
         <section class="col-lg-9">
             <div class="card container mb-2">
                 <div class="row mt-3 justify-content-center">
-                    <h4>작성한 글</h4>
+                    <h4>최근 작성 글</h4>
                     <p class="text-center">글1</p>
                     <p class="text-center">글2</p>
                     <p class="text-center">글3</p>
@@ -91,7 +106,7 @@
             </div>
             <div class="card container">
                 <div class="row mt-3 justify-content-center">
-                    <h4>작성한 댓글</h4>
+                    <h4>최근 작성 댓글</h4>
                     <p class="text-center">댓글1</p>
                     <p class="text-center">댓글2</p>
                     <p class="text-center">댓글3</p>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -95,21 +95,53 @@
             <div class="card container mb-2">
                 <div class="row mt-3 justify-content-center">
                     <h4>최근 작성 글</h4>
-                    <p class="text-center">글1</p>
-                    <p class="text-center">글2</p>
-                    <p class="text-center">글3</p>
-                    <p class="text-center">글4</p>
-                    <p class="text-center">글5</p>
+                    <table class="table table-hover">
+                        <colgroup>
+                            <col style="width: 5%">
+                            <col style="width: 75%">
+                            <col style="width: 20%">
+                        </colgroup>
+                        <thead>
+                        <tr class="text-center">
+                            <th scope="col">#</th>
+                            <th scope="col">제목</th>
+                            <th scope="col">작성일시</th>
+                        </tr>
+                        </thead>
+                        <tbody class="table-group-divider">
+                        <tr class="text-center" th:each="content, c : ${contents}" th:object="${content}">
+                            <th scope="row">[[${c.count}]]</th>
+                            <td><a th:href="|/request/post/${content.get('contentsId')}|" class="text-dark" th:text="${content.get('contents')}">내용</a></td>
+                            <td th:text="${#strings.replace(content.get('datetime'), 'T', ' ')}">날짜</td>
+                        </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
             <div class="card container">
                 <div class="row mt-3 justify-content-center">
                     <h4>최근 작성 댓글</h4>
-                    <p class="text-center">댓글1</p>
-                    <p class="text-center">댓글2</p>
-                    <p class="text-center">댓글3</p>
-                    <p class="text-center">댓글4</p>
-                    <p class="text-center">댓글5</p>
+                    <table class="table table-hover">
+                        <colgroup>
+                            <col style="width: 5%">
+                            <col style="width: 75%">
+                            <col style="width: 20%">
+                        </colgroup>
+                        <thead>
+                        <tr class="text-center">
+                            <th scope="col">#</th>
+                            <th scope="col">제목</th>
+                            <th scope="col">작성일시</th>
+                        </tr>
+                        </thead>
+                        <tbody class="table-group-divider">
+                        <tr class="text-center" th:each="reply, r : ${replies}" th:object="${reply}">
+                            <th scope="row">[[${r.count}]]</th>
+                            <td><a th:href="|/request/post/${reply.get('contentsId')}|" class="text-dark" th:text="${reply.get('contents')}">내용</a></td>
+                            <td th:text="${#strings.replace(reply.get('datetime'), 'T', ' ')}">날짜</td>
+                        </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </section>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -23,7 +23,7 @@
             <div class="card container mb-2 pb-2 pt-2">
 
                 <div class="row mt-3 justify-content-center">
-                    <h4 class="text-center" th:text="${nickname}">nickname</h4>
+                    <h4 id="nickname" class="text-center" th:text="${nickname}">nickname</h4>
                     <p id="email" class="text-center" th:text="${email}">example@example.com</p>
                 </div>
 
@@ -41,9 +41,9 @@
                         이메일 발송 중...
                     </button>
                     </th:block>
-                    <button class="btn-outline-secondary text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
+                    <button id="btnChangeNickname" class="btn-outline-secondary text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
                        data-bs-toggle="modal" data-bs-target="#modal" th:attr="data-bs-whatever=${nickname}">닉네임 변경</button>
-                    <button class="btn-outline-secondary text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
+                    <button id="btnChangePassword" class="btn-outline-secondary text-dark container-fluid mb-2 p-3 pt-1 pb-1 pt-0"
                             data-bs-toggle="modal" data-bs-target="#modal" data-bs-whatever="password-change">비밀번호 변경</button>
                     <button class="btn-outline-secondary text-dark container-fluid p-3 pt-1 pb-1 pt-0">회원 탈퇴</button>
 
@@ -58,17 +58,15 @@
                                     <form>
                                         <div class="mb-3">
                                             <div id="nicknameForm" type="hidden">
-                                                <label for="nickname" class="col-form-label">변경할 닉네임</label>
-                                                <input type="text" class="form-control" id="nickname"
+                                                <label for="nicknameInput" class="col-form-label">변경할 닉네임</label>
+                                                <input type="text" class="form-control" id="nicknameInput" name="nickname"
                                                        aria-describedby="nicknameValidationFeedback">
                                                 <div id="nicknameValidationFeedback" class="invalid-feedback"
-                                                     style="text-overflow: initial; overflow: visible; white-space: initial;">
-                                                    한글, 영어(대/소문자), 숫자로만 입력할 수 있으며 3~8글자만 입력 가능합니다.
-                                                </div>
+                                                     style="text-overflow: initial; overflow: visible; white-space: initial;"></div>
                                             </div>
                                             <div id="passwordForm">
-                                                <label for="password" class="col-form-label">변경할 비밀번호</label>
-                                                <input type="password" class="form-control" id="password"
+                                                <label for="passwordInput" class="col-form-label">변경할 비밀번호</label>
+                                                <input type="password" class="form-control" id="passwordInput" name="password"
                                                        aria-describedby="passwordValidationFeedback">
                                                 <div id="passwordValidationFeedback" class="invalid-feedback"
                                                 style="text-overflow: initial; overflow: visible; white-space: initial;">

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <link th:href="@{/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/css/styles.css}" rel="stylesheet" type="text/css">
     <script th:src="@{/js/jquery-3.7.0.min.js}"></script>
     <script th:src="@{/js/user/mypage.js}"></script>
     <script th:src="@{/js/popper.min.js}"></script>
     <script th:src="@{/js/bootstrap.min.js}"></script>
-    <link th:href="@{/css/styles.css}" rel="stylesheet" type="text/css">
     <style>
         body * {
             text-overflow: ellipsis; overflow: hidden; white-space:nowrap;
@@ -21,15 +21,21 @@
     <div class="row justify-content-between">
         <aside class="col-lg-3">
             <div class="card container mb-2 pb-2 pt-2">
+
                 <div class="row mt-3 justify-content-center">
                     <h4 class="text-center" th:text="${nickname}">nickname</h4>
-                    <p class="text-center" th:text="${email}">email</p>
+                    <p class="text-center" th:text="${email}">example@example.com</p>
                 </div>
+
                 <div class="row m-4 mb-0 mt-0"><hr></div>
+
                 <div class="row justify-content-start">
                     <h5 class="text-center pb-2">계정 관리 메뉴</h5>
-
-                    <button class="btn-outline-secondary text-dark container-fluid p-3 pt-1 pb-1 pt-0"
+                    <th:block th:unless="${verifiedUser}">
+                    <button class="btn-secondary btn-warning text-dark container-fluid p-3 pt-1 pb-1 pt-0"
+                            data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="아직 인증되지 않았어요!">인증 이메일 재발송</button>
+                    </th:block>
+                    <button class="btn-outline-secondary text-dark container-fluid mt-2 p-3 pt-1 pb-1 pt-0"
                        data-bs-toggle="modal" data-bs-target="#modal" th:attr="data-bs-whatever=${nickname}">닉네임 변경</button>
                     <button class="btn-outline-secondary text-dark container-fluid mt-2 p-3 pt-1 pb-1 pt-0"
                             data-bs-toggle="modal" data-bs-target="#modal" data-bs-whatever="password-change">비밀번호 변경</button>

--- a/src/main/resources/templates/reset_password.html
+++ b/src/main/resources/templates/reset_password.html
@@ -42,6 +42,6 @@
     </div>
   </div>
 </div>
-<!--<div th:insert="~{footer :: footer}"></div>-->
+<div th:insert="~{footer :: footer}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/reset_password_code_expired.html
+++ b/src/main/resources/templates/reset_password_code_expired.html
@@ -16,6 +16,6 @@
     </div>
   </div>
 </div>
-<!--<div th:insert="~{footer :: footer}"></div>-->
+<div th:insert="~{footer :: footer}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/welcome_signup.html
+++ b/src/main/resources/templates/welcome_signup.html
@@ -17,6 +17,6 @@
         </div>
     </div>
 </div>
-<!--<div th:insert="~{footer :: footer}"></div>-->
+<div th:insert="~{footer :: footer}"></div>
 </body>
 </html>


### PR DESCRIPTION
회원정보 페이지 내 관련 기능을 추가했습니다.

## 추가 기능
1. ID/PASSWORD 가입 시 인증 메일 실수로 삭제되거나 못받을 경우를 대비해 재발송 기능 추가
2. 닉네임 변경 기능 추가
3. 비밀번호 변경 기능 추가
4. 사용자가 작성한 최근 게시글 확인 기능 추가(일단 현지님꺼 경로로 링크 걸어뒀습니다.)

## 기타
- 전부 회원쪽 기능이라 영향받을 것은 없을 것 같습니다.
- 게시판 목록 불러오는거 만드실 때, 제 코드도 참고하시면 좋을 것 같습니다. th:each 를 사용하실 때 index를 사용하면 0부터 시작인데 count를 사용하면 1부터 시작이라 편합니다.
```html
<tr class="text-center" th:each="content, c : ${contents}" th:object="${content}">
    <th scope="row">[[${c.count}]]</th>
    <td><a th:href="|/request/post/${content.get('contentsId')}|" class="text-dark" th:text="${content.get('contents')}">내용</a></td>
    <td th:text="${#strings.replace(content.get('datetime'), 'T', ' ')}">날짜</td>
</tr>
```
![Screenshot_1](https://github.com/hyseop/NOWNESS/assets/135004614/7d7b6a90-9827-4758-bc51-67ad913ed02b)
