### PR TITLE
헤더 회원 메뉴 추가

### DIFF
--- a/src/main/java/highfive/nowness/controller/MainController.java
+++ b/src/main/java/highfive/nowness/controller/MainController.java
@@ -5,20 +5,20 @@ import highfive.nowness.util.UserUtil;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class MainController {
     @GetMapping({"/main", "/"})
     String main(@AuthenticationPrincipal User user,
-                @AuthenticationPrincipal OAuth2User oAuth2User) {
-        if (UserUtil.isNotLogin(user, oAuth2User)) System.out.println("Not Login");
+                @AuthenticationPrincipal OAuth2User oAuth2User,
+                Model model) {
+        if (!UserUtil.isNotLogin(user, oAuth2User)) {
+            if (user == null) user = UserUtil.convertOAuth2UserToUser(oAuth2User);
+            UserUtil.addPublicUserInfoToModel(model, user);
+        }
         return "main";
-    }
-
-    @GetMapping("/login")
-    public String login() {
-        return "login";
     }
 
     @GetMapping("/rankboard")
@@ -34,11 +34,6 @@ public class MainController {
     @GetMapping("/requestboard")
     public String requestboard() {
         return "requestboard";
-    }
-
-    @GetMapping("/signup")
-    public String signup() {
-        return "signup";
     }
 
     @GetMapping("/privacy")

--- a/src/main/java/highfive/nowness/util/UserUtil.java
+++ b/src/main/java/highfive/nowness/util/UserUtil.java
@@ -17,7 +17,7 @@ public class UserUtil {
     }
 
     public static void addPublicUserInfoToModel(Model model, User user) {
-        model.addAttribute("id", user.getId());
+        model.addAttribute("userId", user.getId());
         model.addAttribute("email", user.getEmail());
         model.addAttribute("nickname", user.getNickname());
         model.addAttribute("verifiedUser", user.isVerifiedEmail());

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -10,10 +10,9 @@
         <nav class="navbar navbar-expand-lg bg-light">
             <div class="container-fluid">
                 <div class="row w-100">
-
                     <div class="col-12 d-flex justify-content-end">
                         <ul class="navbar-nav">
-                            <th:block th:if="${userid == 'null'}">
+                            <th:block th:if="${userId == null}">
                                 <li class="nav-item">
                                     <a class="nav-link text-dark user-link" href="/user/login">로그인</a>
                                 </li>
@@ -21,14 +20,14 @@
                                     <a class="nav-link text-dark user-link" href="/user/signup">회원가입</a>
                                 </li>
                             </th:block>
-                            <th:block th:if="${userid != 'null'}">
+                            <th:block th:if="${userId != null}">
                                 <li class="nav-item">
                                     <p class="nav-link text-dark" th:text="|${nickname}님 안녕하세요!|">닉네임</p>
                                 </li>
                                 <li class="nav-item">
                                     <a class="nav-link user-link"
                                        th:classappend="${verifiedUser} ? 'text-dark' : 'text-warning'"
-                                       th:attr="data-bs-toggle=${verifiedUser ? null : 'tooltip'}, data-bs-placement=${verifiedUser ? null : 'top'}, data-bs-title=${verifiedUser ? null : '아직 인증되지 않았어요!'}"
+                                       th:attr="data-bs-toggle=${verifiedUser ? '' : 'tooltip'}, data-bs-placement=${verifiedUser ? '' : 'top'}, data-bs-title=${verifiedUser ? '' : '아직 인증되지 않았어요!'}"
                                        href="/user/mypage">회원정보</a>
                                 </li>
                                 <li class="nav-item">

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -1,24 +1,40 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html xmlns:th="http://www.thymeleaf.org" th:lang="ko">
 <head>
     <meta charset="UTF-8">
 </head>
 <body>
 <div th:fragment="header">
-
-    <div class="container-fluid">
+    <th:block th:insert="~{tooltip_script}"></th:block>
+    <div class="container-fluid p-0">
         <nav class="navbar navbar-expand-lg bg-light">
             <div class="container-fluid">
                 <div class="row w-100">
 
                     <div class="col-12 d-flex justify-content-end">
                         <ul class="navbar-nav">
-                            <li class="nav-item">
-                                <a class="nav-link text-dark user-link" href="/user/login">로그인</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link text-dark user-link" href="/user/signup">회원가입</a>
-                            </li>
+                            <th:block th:if="${userid == 'null'}">
+                                <li class="nav-item">
+                                    <a class="nav-link text-dark user-link" href="/user/login">로그인</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link text-dark user-link" href="/user/signup">회원가입</a>
+                                </li>
+                            </th:block>
+                            <th:block th:if="${userid != 'null'}">
+                                <li class="nav-item">
+                                    <p class="nav-link text-dark" th:text="|${nickname}님 안녕하세요!|">닉네임</p>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link user-link"
+                                       th:classappend="${verifiedUser} ? 'text-dark' : 'text-warning'"
+                                       th:attr="data-bs-toggle=${verifiedUser ? null : 'tooltip'}, data-bs-placement=${verifiedUser ? null : 'top'}, data-bs-title=${verifiedUser ? null : '아직 인증되지 않았어요!'}"
+                                       href="/user/mypage">회원정보</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link text-dark user-link" href="/user/logout">로그아웃</a>
+                                </li>
+                            </th:block>
                         </ul>
                     </div>
 
@@ -46,7 +62,6 @@
             </div>
         </nav>
     </div>
-
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -64,6 +64,5 @@
 <script th:src="@{js/main/map/map.js}"></script>
 <script th:src="@{//dapi.kakao.com/v2/maps/sdk.js?appkey=APIKEY&libraries=clusterer}" type="text/javascript"></script>
 <div th:insert="~{footer :: footer}"></div>
-<script th:src="@{/static/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -4,10 +4,7 @@
     <meta charset="UTF-8">
     <link th:href="@{/css/bootstrap.min.css}" rel="stylesheet">
     <link th:href="@{/css/styles.css}" rel="stylesheet" type="text/css">
-    <script th:src="@{/js/jquery-3.7.0.min.js}"></script>
     <script th:src="@{/js/user/mypage.js}"></script>
-    <script th:src="@{/js/popper.min.js}"></script>
-    <script th:src="@{/js/bootstrap.min.js}"></script>
     <style>
         body * {
             text-overflow: ellipsis; overflow: hidden; white-space:nowrap;
@@ -16,7 +13,7 @@
     <title>NOWNESS</title>
 </head>
 <body>
-<div th:insert="~{header :: header}"></div>
+<th:block th:insert="~{header :: header}"></th:block>
 <div class="container mt-5">
     <div class="row justify-content-between">
         <aside class="col-lg-3">

--- a/src/main/resources/templates/tooltip_script.html
+++ b/src/main/resources/templates/tooltip_script.html
@@ -1,0 +1,11 @@
+<script th:src="@{/js/jquery-3.7.0.min.js}"></script>
+<script th:src="@{/js/popper.min.js}"></script>
+<script th:src="@{/js/bootstrap.min.js}"></script>
+<script>
+    $(document).ready(function() {
+
+        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+
+    });
+</script>


### PR DESCRIPTION
회원 상태 별로 회원 메뉴가 달라지게 했습니다.

1. 로그인 되지 않은 상태
![image](https://github.com/hyseop/NOWNESS/assets/135004614/87dafaad-41b7-4037-9c14-6f5aaf162e8d)

2. 로그인 됐지만, 이메일 인증하지 않은 상태
![image](https://github.com/hyseop/NOWNESS/assets/135004614/77c15671-82d1-4de4-9bf9-1cbe2e2ac64c)

3. 로그인 되고, 이메일 인증된 상태
![image](https://github.com/hyseop/NOWNESS/assets/135004614/99377fd4-d194-4ef1-9c7e-f6a2bbfba541)

## 관련 코드

아래처럼 로그인한 경우에만 사용자 데이터 추가할 수 있게 해주세요.

```java
@GetMapping({"/main", "/"})
String main(@AuthenticationPrincipal User user,
            @AuthenticationPrincipal OAuth2User oAuth2User,
            Model model) {
    if (!UserUtil.isNotLogin(user, oAuth2User)) {
        if (user == null) user = UserUtil.convertOAuth2UserToUser(oAuth2User);
        UserUtil.addPublicUserInfoToModel(model, user);
    }
    return "main";
}
```

html에서는 userId 존재 여부로 로그인 여부 판단하시면 됩니다.

```html
<th:block th:if="${userId == null}"> 로그인되지 않음
<th:block th:if="${userId != null}"> 로그인됨
```

이메일 인증 여부도 잊지 마세요~~

```html
<th:block th:if="${verifiedUser != null}">
```

## 주의사항
헤더에 js 코드가 들어가서 아래 스크립트 파일들은 헤더에 포함되어 있습니다. 헤더 추가하는 화면에서는 아래 스크립트 선언은 제거해주세요.

```html
<script th:src="@{/js/jquery-3.7.0.min.js}"></script>
<script th:src="@{/js/popper.min.js}"></script>
<script th:src="@{/js/bootstrap.min.js}"></script>
```

## 기타
헤더가 화면에 좌우로 여백 남던거 제거 했습니다.