### PR TITLE
사용자 작성 게시글 및 댓글 전체 확인 게시판 목록 추가

### DIFF
--- a/src/main/java/highfive/nowness/SecurityConfig.java
+++ b/src/main/java/highfive/nowness/SecurityConfig.java
@@ -32,7 +32,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http.authorizeHttpRequests(auth -> {
-                        auth.requestMatchers("/user/mypage", "/user/logout", "/user/withdrawal","/request/modify/*", "/request/writer").hasRole("USER"); // 로그인하지 않은 채로 명시된 경로에 접근하면 로그인 페이지로 redirect
+                        auth.requestMatchers("/user/mypage", "/user/logout", "/user/withdrawal",
+                                "/user/posts", "/user/replies",
+                                "/request/modify/*", "/request/writer").hasRole("USER"); // 로그인하지 않은 채로 명시된 경로에 접근하면 로그인 페이지로 redirect
                         auth.requestMatchers("/admin", "/admin/**").hasRole("ADMIN");
                         auth.requestMatchers("/**").permitAll();})
                 .formLogin(formLoginConfigurer -> formLoginConfigurer

--- a/src/main/java/highfive/nowness/controller/UserController.java
+++ b/src/main/java/highfive/nowness/controller/UserController.java
@@ -120,6 +120,42 @@ public class UserController {
         model.addAttribute("replies", replies);
     }
 
+    @GetMapping({"/posts", "/replies"})
+    public String showUserPostsPage(@AuthenticationPrincipal User user,
+                                @AuthenticationPrincipal OAuth2User oAuth2User,
+                                HttpServletRequest request,
+                                @RequestParam(defaultValue = "1") long page,
+                                Model model) {
+        if (user == null) user = UserUtil.convertOAuth2UserToUser(oAuth2User);
+        UserUtil.addPublicUserInfoToModel(model, user);
+
+        // 요청 식별
+        String uri = request.getRequestURI();
+        String resourceName = uri.substring(uri.lastIndexOf('/') + 1);
+        model.addAttribute("resourceName", resourceName);
+
+        // 게시판 하단, 페이지 선택 메뉴용 데이터 계산 및 추가
+        long totalCount = resourceName.equals("posts") ? userDetailsService.getUserPostsCount(user.getId()) :
+                userDetailsService.getUserRepliesCount(user.getId());
+        long totalPage = totalCount / 10 + (totalCount % 10 == 0 ? 0 : 1);
+        if (page < 1 || page > totalPage) page = 1;
+        model.addAttribute("totalPage", totalPage);
+        long pageOffset = page % 5 == 0 ? 5 : page % 5;
+        model.addAttribute("previousPage", page - pageOffset);
+        model.addAttribute("nextPage", page + 6 - pageOffset);
+
+        // 게시판 화면 타이틀
+        String boardTitle = resourceName.equals("posts") ? "내가 작성한 게시글" : "내가 작성한 댓글";
+        model.addAttribute("boardTitle", boardTitle);
+
+        // 게시글 정보
+        var contents = resourceName.equals("posts") ? userDetailsService.getUserRecentPostsByPage(user.getId(), page) :
+                userDetailsService.getUserRecentRepliesByPage(user.getId(), page);
+        model.addAttribute("contents", contents);
+
+        return "user_posts_replies";
+    }
+
     @GetMapping("/withdrawal")
     public String showWithdrawalPage(@AuthenticationPrincipal User user,
                                      @AuthenticationPrincipal OAuth2User oAuth2User,

--- a/src/main/java/highfive/nowness/repository/BoardRepository.java
+++ b/src/main/java/highfive/nowness/repository/BoardRepository.java
@@ -10,4 +10,8 @@ import java.util.Map;
 @Repository
 public interface BoardRepository {
     List<Map<String, String>> loadRecentContentsAndReplies(long userId);
+    List<Map<String, String>> loadUserRecentPostsByPage(long userId, long page);
+    long loadUserPostsCount(long userId);
+    List<Map<String, String>> loadUserRecentRepliesByPage(long userId, long page);
+    long loadUserRepliesCount(long userId);
 }

--- a/src/main/java/highfive/nowness/service/UserDetailsService.java
+++ b/src/main/java/highfive/nowness/service/UserDetailsService.java
@@ -203,6 +203,26 @@ public class UserDetailsService implements UserService {
         return boardRepository.loadRecentContentsAndReplies(userId);
     }
 
+    @Transactional(readOnly = true)
+    public List<Map<String, String>> getUserRecentPostsByPage(long userId, long page) {
+        return boardRepository.loadUserRecentPostsByPage(userId, (page - 1) * 10);
+    }
+
+    @Transactional(readOnly = true)
+    public long getUserPostsCount(long userId) {
+        return boardRepository.loadUserPostsCount(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Map<String, String>> getUserRecentRepliesByPage(long userId, long page) {
+        return boardRepository.loadUserRecentRepliesByPage(userId, (page - 1) * 10);
+    }
+
+    @Transactional(readOnly = true)
+    public long getUserRepliesCount(long userId) {
+        return boardRepository.loadUserRepliesCount(userId);
+    }
+
     @Transactional
     public boolean withdrawal(long userId) {
         return userRepository.deleteUser(userId) == 1;

--- a/src/main/resources/mapper/board-mapper.xml
+++ b/src/main/resources/mapper/board-mapper.xml
@@ -3,18 +3,38 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="highfive.nowness.repository.BoardRepository">
     <select id="loadRecentContentsAndReplies" parameterType="long" resultType="java.util.HashMap">
-        (SELECT 'contents' AS type,
-                c.id AS contentsId,
-                c.contents AS contents,
-                c.created_datetime AS datetime
+        (SELECT 'contents' AS type, c.id AS contentsId, c.title AS contents, c.created_datetime AS datetime
          FROM Contents c
-         WHERE c.user_id = #{user_id} ORDER BY c.created_datetime DESC LIMIT 0, 5)
+         WHERE c.user_id = #{userId} ORDER BY c.created_datetime DESC LIMIT 0, 5)
         UNION ALL
-        (SELECT 'replies' AS type,
-                r.contents_id AS contentsId,
-                r.reply AS contents,
-                r.created_datetime AS datetime
+        (SELECT 'replies' AS type, r.contents_id AS contentsId, r.reply AS contents, r.created_datetime AS datetime
          FROM Replies r
-         WHERE r.user_id = #{user_id} ORDER BY r.created_datetime DESC LIMIT 0, 5);
+         WHERE r.user_id = #{userId} ORDER BY r.created_datetime DESC LIMIT 0, 5);
+    </select>
+
+    <select id="loadUserRecentPostsByPage" parameterType="long" resultType="java.util.HashMap">
+        SELECT id, title, created_datetime AS datetime
+        FROM contents
+        WHERE user_id = #{arg0}
+        ORDER BY created_datetime DESC LIMIT #{arg1}, 10
+    </select>
+
+    <select id="loadUserPostsCount" parameterType="long" resultType="long">
+        SELECT count(*)
+        FROM contents
+        WHERE user_id = #{arg0}
+    </select>
+
+    <select id="loadUserRecentRepliesByPage" parameterType="long" resultType="java.util.HashMap">
+        SELECT id, SUBSTR(reply, 1, 50) AS title, created_datetime AS datetime
+        FROM replies
+        WHERE user_id = #{arg0}
+        ORDER BY created_datetime DESC LIMIT #{arg1}, 10
+    </select>
+
+    <select id="loadUserRepliesCount" parameterType="long" resultType="long">
+        SELECT count(*)
+        FROM replies
+        WHERE user_id = #{arg0}
     </select>
 </mapper>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -92,7 +92,9 @@
         <section class="col-lg-9">
             <div class="card container mb-2">
                 <div class="row mt-3 justify-content-center">
-                    <h4>최근 작성 글</h4>
+                    <h4 class="col-10">최근 작성 글</h4>
+                    <a class="col-2 text-center text-decoration-none text-dark fw-bold text-decoration-underline"
+                       th:href="@{/user/posts}">전체 보기</a>
                     <table class="table table-hover">
                         <colgroup>
                             <col style="width: 5%">
@@ -118,7 +120,9 @@
             </div>
             <div class="card container">
                 <div class="row mt-3 justify-content-center">
-                    <h4>최근 작성 댓글</h4>
+                    <h4 class="col-10">최근 작성 댓글</h4>
+                    <a class="col-2 text-center text-decoration-none text-dark fw-bold text-decoration-underline"
+                       th:href="@{/user/replies}">전체 보기</a>
                     <table class="table table-hover">
                         <colgroup>
                             <col style="width: 5%">

--- a/src/main/resources/templates/user_posts_replies.html
+++ b/src/main/resources/templates/user_posts_replies.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <link th:href="@{/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/css/styles.css}" rel="stylesheet" type="text/css">
+    <style>
+        body * {
+            text-overflow: ellipsis; overflow: hidden; white-space:nowrap;
+        }
+    </style>
+    <title>NOWNESS</title>
+</head>
+<body>
+<header>
+    <th:block th:insert="~{header :: header}"></th:block>
+</header>
+<div class="container mt-5">
+    <div class="row justify-content-between">
+        <section class="container-fluid">
+            <div class="card container mb-2">
+                <div class="row mt-3 justify-content-center">
+                    <h4 th:text="${boardTitle}"></h4>
+                    <table class="table table-hover">
+                        <colgroup>
+                            <col style="width: 5%">
+                            <col style="width: 75%">
+                            <col style="width: 20%">
+                        </colgroup>
+                        <thead>
+                        <tr class="text-center">
+                            <th scope="col">#</th>
+                            <th scope="col">제목</th>
+                            <th scope="col">작성일시</th>
+                        </tr>
+                        </thead>
+                        <tbody class="table-group-divider">
+                        <tr class="text-center" th:each="content, c : ${contents}" th:object="${contents}">
+                            <th scope="row">[[${c.count}]]</th>
+                            <td><a th:href="|/request/post/${content.get('id')}|" class="text-dark" th:text="${content.get('title')}">제목</a></td>
+                            <td th:text="${#strings.replace(content.get('datetime'), 'T', ' ')}">작성일시</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                    <nav th:if="${totalPage > 0}" aria-label="Page navigation example">
+                        <ul class="pagination justify-content-center" th:with="currentPage=${param.page == null ? '1' : param.page}">
+                            <li class="page-item"
+                                th:classappend="${previousPage == 0} ? 'disabled' : ''">
+                                <a class="page-link" th:href="@{/user/__${resourceName}__(page=${previousPage})}">이전</a>
+                            </li>
+                            <th:block th:with="pageNumbers=${#numbers.sequence(previousPage + 1, (nextPage - 1 > totalPage ? totalPage : nextPage - 1))}">
+                                <li class="page-item" th:each="pageNumber:${pageNumbers}"
+                                    th:classappend="${#strings.equals(currentPage, #strings.toString(pageNumber))} ? 'active' : ''">
+                                    <a class="page-link" th:href="@{/user/__${resourceName}__(page=${pageNumber})}">[[${pageNumber}]]</a>
+                                </li>
+                            </th:block>
+                            <li class="page-item"
+                                th:classappend="${nextPage > totalPage} ? 'disabled' : ''">
+                                <a class="page-link" th:href="@{/user/__${resourceName}__(page=${nextPage})}">다음</a>
+                            </li>
+                        </ul>
+                    </nav>
+                    <th:block th:if="${totalPage == 0}">
+                        <h4 class="text-center text-muted">작성하신 글이 없습니다. 원하시는 메뉴를 선택하시고, 글을 남겨보세요.</h4>
+                    </th:block>
+                </div>
+            </div>
+        </section>
+    </div>
+</div>
+<footer th:insert="~{footer :: footer}"></footer>
+</body>
+</html>


### PR DESCRIPTION
사용자가 작성한 게시글 및 댓글을 전체적으로 확인할 수 있도록 회원정보 페이지에서 접근할 수 있는 링크와 게시판을 추가하였습니다.

## 회원정보 페이지 내 추가된 링크

![회원정보 페이지 화면](https://github.com/hyseop/NOWNESS/assets/135004614/4c3c3cbc-6441-4ae1-b82c-ee39e3c44be2)

## 작성한 게시글 

![내가 작성한 게시글 화면](https://github.com/hyseop/NOWNESS/assets/135004614/c4caf7fb-a462-4ccb-a817-8b327f3a6ffe)

## 작성한 댓글

![내가 작성한 댓글 화면](https://github.com/hyseop/NOWNESS/assets/135004614/6e895e5a-7502-4d82-8871-48dd03191d61)

## 기타

- 페이지 선택 버튼은 5개 단위로 나타나게 했습니다.
- 이전, 다음 페이지 버튼은 5개 페이지 단위로 이동하게 했습니다.
- 최근에 작성한 글이 가장 앞으로 옵니다.