### PR TITLE
인증 및 비밀번호 변경 이메일 발송 시 링크 주소 수정

### DIFF
--- a/src/main/java/highfive/nowness/util/UserUtil.java
+++ b/src/main/java/highfive/nowness/util/UserUtil.java
@@ -32,7 +32,7 @@ public class UserUtil {
     }
 
     public static String getHost() {
-        return "http://localhost:8080";
+        return "http://101.101.218.244/:8080";
     }
 
 }


### PR DESCRIPTION
인증 및 비밀번호 변경 이메일 발송 시 링크가 localhost 로 되어 제 공인 IP로 수정했습니다.

배포 시에는 각자 공인 IP 로 수정이 필요합니다.